### PR TITLE
fix: Invalid Token on OneLogin API

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -4,23 +4,6 @@ TARGET=${1:-"-func"}
 
 cd $CWD
 [ -e $CWD/.coverage ] || mkdir $CWD/.coverage
-find ${CWD} \
-    -name '*.go' \
-    -not -path "*/vendor/*" \
-    -not -name "interface.go" \
-    -not -name "main.go" \
-    -not -name "env.go" | \
-        sed -E "s@$GOPATH/src/@@g" | \
-        xargs -I{} dirname {} | \
-        sort | \
-        uniq | \
-        while read DIR; do
-            echo "test: ${DIR}"
-            FILE=.coverage/$(echo $DIR | sed -E 's@/@_@g').out
-            go test $DIR -cover -coverprofile=${FILE}
-            if [ -f $FILE ]; then
-                echo "coverage:"
-                go tool cover ${TARGET} $FILE
-            fi
-            echo ""
-        done
+FILE=".coverage/coverage.out"
+go test ./... -cover -coverprofile=${FILE}
+go tool cover -func=${FILE}

--- a/env.go
+++ b/env.go
@@ -2,5 +2,5 @@ package main
 
 const (
 	// Version app version
-	Version string = "0.1.4"
+	Version string = "0.1.5"
 )

--- a/onelogin/credentials/credentials.go
+++ b/onelogin/credentials/credentials.go
@@ -54,7 +54,13 @@ func (c *Credentials) Refresh() error {
 			}
 			res, err = c.Tokens.Refresh(input)
 			if err != nil {
-				return err
+				if err.Error() != "[401] Unauthorized: Invalid Token" {
+					return err
+				}
+				res, err = c.Tokens.Generate()
+				if err != nil {
+					return err
+				}
 			}
 		} else {
 			res, err = c.Tokens.Generate()


### PR DESCRIPTION
If OneLogin token is invalid, regenerate OneLogin token.