### PR TITLE
エラーハンドリングの追加

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -193,10 +193,16 @@ var loginCmd = &cobra.Command{
 				"aws_session_token":     *creds.SessionToken,
 			}
 			awsCredentials := configuration.NewCredentials(awsDir, awsProfile)
-			_ = awsCredentials.Save(options)
+			err = awsCredentials.Save(options)
+			if err != nil {
+				return nil, err
+			}
 			if region != "" {
 				awsConfig := configuration.NewConfig(awsDir, awsProfile)
-				_ = awsConfig.Save(region)
+				err = awsConfig.Save(region)
+				if err != nil {
+					return nil, err
+				}
 			}
 			return creds, nil
 		})


### PR DESCRIPTION
**PR内容**
- [awsCredentials.Save(options)](https://github.com/lifull-dev/onelogin-aws-connector/blob/master/cmd/login.go#L196)のエラーハンドリングの追加
- [awsConfig.Save(region)](https://github.com/lifull-dev/onelogin-aws-connector/blob/master/cmd/login.go#L199)のエラーハンドリングの追加

**PR理由**
.awsディレクトリが存在せずにloginコマンドを利用した場合に、[awsCredentials.Save(options)](https://github.com/lifull-dev/onelogin-aws-connector/blob/master/cmd/login.go#L196)でエラーが発生し失敗しますが、エラーハンドリングされていなかったため原因調査に難航しました。
[awsCredentials.Save(options)](https://github.com/lifull-dev/onelogin-aws-connector/blob/master/cmd/login.go#L196)の戻り値はerrorであり、ハンドリングされておくべきなので、エラーハンドリングを追加しました。（awsConfig.Save(region)の方もついでに追加しておきました。）

**備考**

.awsディレクトリが存在しない場合の[awsCredentials.Save(options)](https://github.com/lifull-dev/onelogin-aws-connector/blob/master/cmd/login.go#L196)の戻り値
- 2020/09/17 13:03:22 login.go:198: open /Users/202004004/.aws/credentials: no such file or directory

