### PR TITLE
.awsディレクトリが存在しない場合にディレクトリを生成する部分のバグフィックス

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func init() {
 		}
 	}
 	awsDir = path.Join(home, ".aws")
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(awsDir, 0700); err != nil {
 		if !os.IsExist(err) {
 			errorExit(err)
 		}


### PR DESCRIPTION
関連PR
https://github.com/lifull-dev/onelogin-aws-connector/pull/5