### PR TITLE
Fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-go get github.com/lifull-dev/onelogin-aws-connector
+go install github.com/lifull-dev/onelogin-aws-connector@latest
 ```
 
 ## Using the OneLogin AWS Connector


### PR DESCRIPTION
`go get` command is deprecated since Go 1.17.

Ref: https://golang.org/doc/go-get-install-deprecation